### PR TITLE
fixed body of requestOption

### DIFF
--- a/src/app/services/apidoc.service.ts
+++ b/src/app/services/apidoc.service.ts
@@ -80,10 +80,10 @@ export class ApiDocService {
 
         if(operation.isWriteMethod()) {
             if(operation.isConsumeJson()) {
-                reqOptions.body = JSON.stringify(operation.originalData);
+                reqOptions.body = operation.dataJson;
             }
             if(operation.isConsumeXml()) {
-                reqOptions.body = x2js.js2xml(operation.originalData);
+                reqOptions.body = operation.dataJson;
             }
             if(operation.isConsumeFormUrlEncoded()) {
                 let formBody:string = '';


### PR DESCRIPTION
There is an error after sending the body-request, he contains always the default-body.
example: the default-body: {"name": "string"}, The user change it with {"name":"wiem"} after send it, it still {"name": "string"}
